### PR TITLE
受注のマルチ検索で、会社名はスペースを除去せず検索

### DIFF
--- a/src/Eccube/Repository/OrderRepository.php
+++ b/src/Eccube/Repository/OrderRepository.php
@@ -114,10 +114,11 @@ class OrderRepository extends AbstractRepository
             }
             $qb
                 ->andWhere('o.id = :multi OR CONCAT(o.name01, o.name02) LIKE :likemulti OR '.
-                            'CONCAT(o.kana01, o.kana02) LIKE :likemulti OR o.company_name LIKE :likemulti OR '.
+                            'CONCAT(o.kana01, o.kana02) LIKE :likemulti OR o.company_name LIKE :company_name OR '.
                             'o.order_no LIKE :likemulti OR o.email LIKE :likemulti OR o.phone_number LIKE :likemulti')
                 ->setParameter('multi', $multi)
-                ->setParameter('likemulti', '%'.$clean_key_multi.'%');
+                ->setParameter('likemulti', '%'.$clean_key_multi.'%')
+                ->setParameter('company_name', '%'.$searchData['multi'].'%'); // 会社名はスペースを除去せず検索
         }
 
         // order_id_end

--- a/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/OrderRepositoryTest.php
@@ -14,8 +14,8 @@
 namespace Eccube\Tests\Repository;
 
 use Eccube\Entity\Customer;
-use Eccube\Entity\Order;
 use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Order;
 use Eccube\Repository\OrderRepository;
 use Eccube\Tests\EccubeTestCase;
 
@@ -125,12 +125,81 @@ class OrderRepositoryTest extends EccubeTestCase
         $Order = $this->createOrder($this->createCustomer('2147483648@example.com'));
         $Order->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW));
         $this->orderRepository->save($Order);
-        $this->entityManager->flush();;
+        $this->entityManager->flush();
 
         $actual = $this->orderRepository->getQueryBuilderBySearchDataForAdmin(['multi' => '2147483648'])
             ->getQuery()
             ->getResult();
 
         self::assertEquals($Order, $actual[0]);
+    }
+
+    /**
+     * @dataProvider dataGetQueryBuilderBySearchDataForAdmin_nameProvider
+     */
+    public function testGetQueryBuilderBySearchDataForAdmin_name(string $formName, string $searchWord, int $expected)
+    {
+        $this->Order
+            ->setOrderStatus($this->entityManager->find(OrderStatus::class, OrderStatus::NEW))
+            ->setName01('姓')
+            ->setName02('名')
+            ->setKana01('セイ')
+            ->setKana02('メイ')
+            ->setCompanyName('株式会社　会社名'); // 全角スペース
+        $this->orderRepository->save($this->Order);
+        $this->entityManager->flush();
+
+        $actual = $this->orderRepository->getQueryBuilderBySearchDataForAdmin([$formName => $searchWord])
+            ->getQuery()
+            ->getResult();
+
+        self::assertCount($expected, $actual);
+    }
+
+    public function dataGetQueryBuilderBySearchDataForAdmin_nameProvider()
+    {
+        return [
+            ['multi', '姓', 1],
+            ['multi', '名', 1],
+            ['multi', '姓名', 1],
+            ['multi', '姓 名', 1],
+            ['multi', '姓　名', 1],
+            ['multi', 'セイ', 1],
+            ['multi', 'メイ', 1],
+            ['multi', 'セイメイ', 1],
+            ['multi', 'セイ メイ', 1],
+            ['multi', 'セイ　メイ', 1],
+            ['multi', '株式会社', 1],
+            ['multi', '会社名', 1],
+            ['multi', '株式会社会社名', 0],
+            ['multi', '株式会社 会社名', 0], // 半角スペース
+            ['multi', '株式会社　会社名', 1], // 全角スペース
+            ['multi', '石', 0],
+            ['multi', 'キューブ', 0],
+            ['multi', '姓 球部', 0],
+            ['multi', 'セイ 名', 0],
+            ['multi', '姓　メイ', 0],
+            ['name', '姓', 1],
+            ['name', '名', 1],
+            ['name', '姓名', 1],
+            ['name', '姓 名', 1],
+            ['name', '姓　名', 1],
+            ['name', 'セイ', 0],
+            ['name', '株式会社　会社名', 0],
+            ['kana', 'セイ', 1],
+            ['kana', 'メイ', 1],
+            ['kana', 'セイメイ', 1],
+            ['kana', 'セイ メイ', 1],
+            ['kana', 'セイ　メイ', 1],
+            ['kana', '姓', 0],
+            ['kana', '株式会社　会社名', 0],
+            ['company_name', '株式会社', 1],
+            ['company_name', '会社名', 1],
+            ['company_name', '株式会社会社名', 0],
+            ['company_name', '株式会社 会社名', 0], // 半角スペース
+            ['company_name', '株式会社　会社名', 1], // 全角スペース
+            ['company_name', '姓', 0],
+            ['company_name', 'セイ', 0],
+        ];
     }
 }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

https://github.com/EC-CUBE/ec-cube/pull/4766 のテストが落ちていた件について

会社名はスペースの入力ができます。
例えば「株式会社　ほげほげ」という会社名だった場合に、前処理でスペースが除去され、「株式会社ほげほげ」で検索されてしまっていたため、検索結果がヒットしなくなっていました。
受注のマルチ検索で、会社名はスペースを除去せず検索できるようにしました。

## 方針(Policy)

テストを正としてプロダクトコードを修正しています。

## 実装に関する補足(Appendix)

## テスト（Test)

落ちていたテスト `Eccube\Tests\Web\Admin\Order\OrderControllerTest::testSearchOrderByName` が通ることを確認
